### PR TITLE
API streamlining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8a41e51fda5f7d87152d00f50d08ce24bf5cee8a962facf7f2526a66f8a5fa"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b592add4016ac26ca340298fed5cc2524abe8bacae78ebca3780286da588304"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +614,41 @@ dependencies = [
  "tracing-subscriber",
  "tracing-web",
  "worker",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1298,6 +1358,12 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 dependencies = [
  "rayon",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3724,6 +3790,7 @@ version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum",
+ "bon",
  "bytes",
  "chrono",
  "chrono-tz",

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [dependencies]
 async-trait.workspace = true
+bon = "3.4.0"
 bytes = "1.5"
 chrono.workspace = true
 futures-channel.workspace = true

--- a/worker/src/email.rs
+++ b/worker/src/email.rs
@@ -1,3 +1,10 @@
+//! Email module for sending and receiving email messages.
+//!
+//! Note: Some tests for this module require wasm_bindgen, and won't run on the native target.
+//! Specifically, conversion tests for [`EmailMessage`] and [`RawEmailMessage`] require wasm_bindgen.
+use std::{convert::TryFrom, fmt::Display};
+
+use bon::bon;
 use futures_util::TryStreamExt;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::ReadableStream;
@@ -9,8 +16,39 @@ pub struct EmailMessage {
     pub inner: EmailMessageSys,
 }
 
+#[bon]
 impl EmailMessage {
-    /// construct a new email message
+    /// Construct a new email message
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use worker::{EmailMessage, RawEmailMessage};
+    ///
+    /// let from_email = "source@example.com";
+    /// let to_email = "destination@example.com";
+    /// let subject = "Hello, World!";
+    /// let date = "Sat, 15 Mar 2025 22:06:02 +0000";
+    /// let message_id = "<message_id>";
+    /// let message = "Hello, World!";
+    ///
+    /// let msg = RawEmailMessage::builder()
+    ///   .from_email(from_email)
+    ///   .to_email(to_email)
+    ///   .subject(subject)
+    ///   .date(date)
+    ///   .message_id(message_id)
+    ///   .message(message)
+    ///   .build()
+    ///   .to_string();
+    ///
+    /// let email = EmailMessage::builder()
+    ///    .from("source@example.com")
+    ///    .to("destination@email.com")
+    ///    .raw(msg)
+    ///    .build();
+    /// ```
+    #[builder]
     pub fn new(from: &str, to: &str, raw: &str) -> Result<Self> {
         Ok(EmailMessage {
             inner: EmailMessageSys::new(from, to, raw)?,
@@ -81,5 +119,315 @@ impl EmailMessage {
         let fut = SendFuture::new(JsFuture::from(promise));
         fut.await?;
         Ok(())
+    }
+}
+
+/// Raw message builder uses the type system to build raw email messages.
+///
+/// # Example
+///
+/// ```rust
+/// let msg_built = RawEmailMessage::builder()
+///    // mandatory fields
+///    .from_email("bot@cloudflare.com")
+///    .from_name("Cloudflare bot")
+///    .to_email("toon@example.com")
+///    .to_name("Toon")
+///    .subject("Email well received!")
+///    .date("Sat, 15 Mar 2025 22:06:02 +0000")
+///    // optional fields
+///    .cc_email("another@example.com")
+///    .cc_name("Another User")
+///    .bcc_email("hidden@example.com")
+///    .bcc_name("Hidden User")
+///    .build();
+/// ```
+///
+/// ## Mandatory Fields:
+///
+/// From: This field specifies the sender's email address.
+/// To: This field specifies the recipient's email address.
+/// Subject: This field specifies the subject of the email.
+/// Date: This field specifies the date and time the email was sent. It must follow a specific format as per the Internet Message Format standard (RFC 5322): Date: <day-of-week>, <day> <month> <year> <hour>:<minute>:<second> <timezone>.
+/// Message-ID: This is a unique identifier for the email message.
+///
+/// ## Optional Fields:
+///
+/// Cc: This field specifies additional recipients who will receive a copy of the email.
+/// Bcc: This field specifies recipients who will receive a blind copy of the email (other recipients will not see these addresses).
+/// In-Reply-To: This field references the Message-ID of the email being replied to, used in threading email conversations.
+/// References: This field contains the Message-ID of the previous emails in a thread.
+/// Reply-To: This field specifies an email address where replies should be sent, different from the sender's address.
+/// Content-Type: This field specifies the MIME type of the email content, which is important for formatting (e.g., text/plain, text/html).
+///
+/// ## Optinoal Custom Headers
+///
+/// X-Original-To: Indicates the original recipient address before any forwarding.
+/// X-Mailer: Specifies the software used to send the email.
+/// X-Priority: Specifies the priority of the email (e.g., 1 for highest priority).
+/// X-MSMail-Priority: Similar to X-Priority, used by Microsoft email clients.
+/// X-Spam-Status: Indicates if the email has been flagged as spam.
+/// X-Spam-Score: Provides a numeric score indicating the likelihood of the email being spam.
+/// X-Spam-Flag: Indicates whether the email is flagged as spam (YES or NO).
+/// X-Spam-Report: Provides a detailed report on the spam score.
+/// X-Spam-Level: Provides a visual representation of the spam score.
+/// X-Spam-Checker-Version: Specifies the version of the spam checker used.
+#[derive(Debug)]
+pub struct RawEmailMessage<'a> {
+    // Mandatory fields
+    from_email: &'a str,
+    from_name: &'a str,
+    to_email: &'a str,
+    to_name: &'a str,
+    subject: &'a str,
+    date: &'a str,
+    message: &'a str,
+    message_id: &'a str,
+    // Optional fields
+    cc_email: Option<&'a str>,
+    cc_name: Option<&'a str>,
+    bcc_email: Option<&'a str>,
+    bcc_name: Option<&'a str>,
+    in_reply_to: Option<&'a str>,
+    references: Option<&'a str>,
+    reply_to: Option<&'a str>,
+    content_type: Option<&'a str>,
+    x_original_to: Option<&'a str>,
+    x_mailer: Option<&'a str>,
+    x_priority: Option<&'a str>,
+    x_msmail_priority: Option<&'a str>,
+    x_spam_status: Option<&'a str>,
+    x_spam_score: Option<&'a str>,
+    x_spam_flag: Option<&'a str>,
+    x_spam_report: Option<&'a str>,
+    x_spam_level: Option<&'a str>,
+    x_spam_checker_version: Option<&'a str>,
+}
+
+#[bon]
+impl<'a> RawEmailMessage<'a> {
+    /// Construct a new email message
+    ///
+    /// Takes string slices for all fields.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let msg_built = RawEmailMessage::builder()
+    ///    // mandatory fields
+    ///    .from_email("bot@cloudflare.com")
+    ///    .from_name("Cloudflare bot")
+    ///    .to_email("toon@example.com")
+    ///    .to_name("Toon")
+    ///    .subject("Email well received!")
+    ///    .date("Sat, 15 Mar 2025 22:06:02 +0000")
+    ///    // optional fields
+    ///    .cc_email("another@example.com")
+    ///    .cc_name("Another User")
+    ///    .bcc_email("hidden@example.com")
+    ///    .bcc_name("Hidden User")
+    ///    .build();
+    ///
+    /// let email = EmailMessage::try_from(msg_built).unwrap();
+    /// ```
+    #[builder]
+    pub fn new(
+        from_email: &'a str,
+        from_name: &'a str,
+        to_email: &'a str,
+        to_name: &'a str,
+        subject: &'a str,
+        date: &'a str,
+        message_id: &'a str,
+        message: &'a str,
+        cc_email: Option<&'a str>,
+        cc_name: Option<&'a str>,
+        bcc_email: Option<&'a str>,
+        bcc_name: Option<&'a str>,
+        in_reply_to: Option<&'a str>,
+        references: Option<&'a str>,
+        reply_to: Option<&'a str>,
+        content_type: Option<&'a str>,
+        x_original_to: Option<&'a str>,
+        x_mailer: Option<&'a str>,
+        x_priority: Option<&'a str>,
+        x_msmail_priority: Option<&'a str>,
+        x_spam_status: Option<&'a str>,
+        x_spam_score: Option<&'a str>,
+        x_spam_flag: Option<&'a str>,
+        x_spam_report: Option<&'a str>,
+        x_spam_level: Option<&'a str>,
+        x_spam_checker_version: Option<&'a str>,
+    ) -> Self {
+        RawEmailMessage {
+            from_email,
+            from_name,
+            to_email,
+            to_name,
+            subject,
+            date,
+            message_id,
+            message,
+            cc_email,
+            cc_name,
+            bcc_email,
+            bcc_name,
+            in_reply_to,
+            references,
+            reply_to,
+            content_type,
+            x_original_to,
+            x_mailer,
+            x_priority,
+            x_msmail_priority,
+            x_spam_status,
+            x_spam_score,
+            x_spam_flag,
+            x_spam_report,
+            x_spam_level,
+            x_spam_checker_version,
+        }
+    }
+}
+
+impl Display for RawEmailMessage<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut msg = format!(
+            "From: {} <{}>\nTo: {} <{}>\nSubject: {}\nDate: {}\nMessage-ID: {}\n",
+            self.from_name,
+            self.from_email,
+            self.to_name,
+            self.to_email,
+            self.subject,
+            self.date,
+            self.message_id
+        );
+
+        if let Some(cc_email) = self.cc_email {
+            msg.push_str(&format!(
+                "Cc: {} <{}>\n",
+                self.cc_name.unwrap_or(""),
+                cc_email
+            ));
+        }
+
+        if let Some(bcc_email) = self.bcc_email {
+            msg.push_str(&format!(
+                "Bcc: {} <{}>\n",
+                self.bcc_name.unwrap_or(""),
+                bcc_email
+            ));
+        }
+
+        if let Some(in_reply_to) = self.in_reply_to {
+            msg.push_str(&format!("In-Reply-To: {}\n", in_reply_to));
+        }
+
+        if let Some(references) = self.references {
+            msg.push_str(&format!("References: {}\n", references));
+        }
+
+        if let Some(reply_to) = self.reply_to {
+            msg.push_str(&format!("Reply-To: {}\n", reply_to));
+        }
+
+        if let Some(content_type) = self.content_type {
+            msg.push_str(&format!("Content-Type: {}\n", content_type));
+        }
+
+        if let Some(x_original_to) = self.x_original_to {
+            msg.push_str(&format!("X-Original-To: {}\n", x_original_to));
+        }
+
+        if let Some(x_mailer) = self.x_mailer {
+            msg.push_str(&format!("X-Mailer: {}\n", x_mailer));
+        }
+
+        if let Some(x_priority) = self.x_priority {
+            msg.push_str(&format!("X-Priority: {}\n", x_priority));
+        }
+
+        if let Some(x_msmail_priority) = self.x_msmail_priority {
+            msg.push_str(&format!("X-MSMail-Priority: {}\n", x_msmail_priority));
+        }
+
+        if let Some(x_spam_status) = self.x_spam_status {
+            msg.push_str(&format!("X-Spam-Status: {}\n", x_spam_status));
+        }
+
+        if let Some(x_spam_score) = self.x_spam_score {
+            msg.push_str(&format!("X-Spam-Score: {}\n", x_spam_score));
+        }
+
+        if let Some(x_spam_flag) = self.x_spam_flag {
+            msg.push_str(&format!("X-Spam-Flag: {}\n", x_spam_flag));
+        }
+
+        if let Some(x_spam_report) = self.x_spam_report {
+            msg.push_str(&format!("X-Spam-Report: {}\n", x_spam_report));
+        }
+
+        if let Some(x_spam_level) = self.x_spam_level {
+            msg.push_str(&format!("X-Spam-Level: {}\n", x_spam_level));
+        }
+
+        if let Some(x_spam_checker_version) = self.x_spam_checker_version {
+            msg.push_str(&format!(
+                "X-Spam-Checker-Version: {}\n",
+                x_spam_checker_version
+            ));
+        }
+
+        msg.push('\n');
+        msg.push_str(self.message);
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl TryFrom<RawEmailMessage<'_>> for EmailMessage {
+    type Error = crate::Error;
+
+    fn try_from(value: RawEmailMessage) -> Result<Self> {
+        EmailMessage::builder()
+            .from(value.from_email)
+            .to(value.to_email)
+            .raw(&value.to_string())
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_raw_email_message() {
+        let from_email = "from@example.com";
+        let from_name = "From Name";
+        let to_email = "to@example.com";
+        let to_name = "To Name";
+        let subject = "Test Email";
+        let date = "Sat, 15 Mar 2025 22:06:02 +0000";
+        let message_id = "<message_id>";
+        let message = "Hello, World!";
+
+        let msg = RawEmailMessage::builder()
+            .from_email(from_email)
+            .from_name(from_name)
+            .to_email(to_email)
+            .to_name(to_name)
+            .subject(subject)
+            .date(date)
+            .message_id(message_id)
+            .message(message)
+            .build();
+
+        let expected = format!(
+            "From: {} <{}>\nTo: {} <{}>\nSubject: {}\nDate: {}\nMessage-ID: {}\n\n{}",
+            from_name, from_email, to_name, to_email, subject, date, message_id, message
+        );
+
+        assert_eq!(msg.to_string(), expected);
     }
 }


### PR DESCRIPTION
Use type system to make the API more robust and easy to use

enables this API:

```rust
use uuid::Uuid;
use worker::*;

#[event(email)]
async fn main(message: EmailMessage, _env: Env, _ctx: Context) -> Result<()> {

    let new_message = EmailMessage::try_from(
        RawEmailMessage::builder()
            .from_name("From Name")
            .from_email(&message.to_email())
            .to_name("To Name")
            .to_email(&message.from_email())
            .subject("Email well received!")
            .date("Sat, 15 Mar 2025 22:06:02 +0000")
            .message_id(format!("{}@redacted.com", Uuid::new_v4()))
            .in_reply_to(message.headers().get("Message-ID")?.unwrap())
            .message("I've parsed the mail!")
            .build(),
    );

    message.reply(new_message).await?;

    Ok(())
}
```